### PR TITLE
fix: escape single quotes in response body

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -260,7 +260,7 @@ local function curl_cmd(opts)
 		if json_body then
 			-- Format JSON output and then add it into the buffer
 			-- line by line because Vim doesn't allow strings with newlines
-			local out = fn.system("echo -E '" .. string.gsub(line, "[']", "\\%1") .. "' | jq .")
+			local out = fn.system("jq", line)
 			for _, _line in ipairs(utils.split(out, '\n')) do
 				line_count = api.nvim_buf_line_count(res_bufnr) - 1
 				api.nvim_buf_set_lines(

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -260,7 +260,7 @@ local function curl_cmd(opts)
 		if json_body then
 			-- Format JSON output and then add it into the buffer
 			-- line by line because Vim doesn't allow strings with newlines
-			local out = fn.system("echo -E '" .. line .. "' | jq .")
+			local out = fn.system("echo -E '" .. string.gsub(line, "[']", "\\%1") .. "' | jq .")
 			for _, _line in ipairs(utils.split(out, '\n')) do
 				line_count = api.nvim_buf_line_count(res_bufnr) - 1
 				api.nvim_buf_set_lines(


### PR DESCRIPTION
This PR should fix the escaping of the single quotes in the response body. Should close #12

@rudotriton could you please test it to see if everything is alright? I didn't tested it, but should be working well.