### PR TITLE
feat: add verbose command to preview cURL requests

### DIFF
--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -87,7 +87,12 @@ Notes:
 ===============================================================================
 COMMANDS                                             *rest-nvim-usage-commands*
 
-| `<Plug>RestNvim` | Run `rest.nvim` in the current cursor position.
+- `<Plug>RestNvim`
+  Run `rest.nvim` in the current cursor position.
+
+- `<Plug>RestNvimPreview`
+  Same as `RestNvim` but it returns the cURL command without executing the
+  request. Intended for debugging purposes.
 
 
 ===============================================================================

--- a/plugin/rest-nvim.vim
+++ b/plugin/rest-nvim.vim
@@ -6,6 +6,7 @@ endif
 if exists('g:loaded_rest_nvim') | finish | endif
 
 nnoremap <Plug>RestNvim :lua require('rest-nvim').run()<CR>
+nnoremap <Plug>RestNvimPreview :lua require('rest-nvim').run(true)<CR>
 
 let s:save_cpo = &cpo
 set cpo&vim


### PR DESCRIPTION
This PR aims to add verbosity to `rest.nvim` by using of the `dry_run` field in the plenary cURL wrapper in the `run` function.

## Added commands

- `<Plug>RestNvimPreview`
  - Same as `RestNvim` command but it returns the cURL command without executing the request. Intended for debugging purposes.

---

I have also added more traceback information for when the request fails so it can be debugged faster.