### PR TITLE
fix: ignore commented lines as it should be

### DIFF
--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -87,7 +87,12 @@ Notes:
 ===============================================================================
 COMMANDS                                             *rest-nvim-usage-commands*
 
-| `<Plug>RestNvim` | Run `rest.nvim` in the current cursor position.
+- `<Plug>RestNvim`
+  Run `rest.nvim` in the current cursor position.
+
+- `<Plug>RestNvimPreview`
+  Same as `RestNvim` but it returns the cURL command without executing the
+  request. Intended for debugging purposes.
 
 
 ===============================================================================

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -83,8 +83,10 @@ local function get_body(bufnr, stop_line, query_line, json_body)
 			false
 		)
 
-		for _, v in ipairs(json_lines) do
-			json_string = json_string .. utils.replace_env_vars(v)
+		for _, json_line in ipairs(json_lines) do
+			if json_line:find('^#') == nil then
+				json_string = json_string .. utils.replace_env_vars(json_line)
+			end
 		end
 
 		json_string = '{' .. json_string .. '}'
@@ -182,7 +184,9 @@ local function get_accept(bufnr, query_line)
 		)
 
 		for _, accept_data in pairs(accept_line) do
-			accept = utils.split(accept_data, ':')[2]
+			if accept_data:find('^#') == nil then
+				accept = utils.split(accept_data, ':')[2]
+			end
 		end
 	end
 
@@ -213,10 +217,12 @@ local function get_auth(bufnr, query_line)
 		)
 
 		for _, auth_data in pairs(auth_line) do
-			-- Split by spaces, e.g. {'Authorization:', 'user:pass'}
-			auth_data = utils.split(auth_data, '%s+')
-			-- {'user', 'pass'}
-			auth = utils.split(utils.replace_env_vars(auth_data[2]), ':')
+			if auth_data:find('^#') == nil then
+				-- Split by spaces, e.g. {'Authorization:', 'user:pass'}
+				auth_data = utils.split(auth_data, '%s+')
+				-- {'user', 'pass'}
+				auth = utils.split(utils.replace_env_vars(auth_data[2]), ':')
+			end
 		end
 	end
 

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -84,7 +84,7 @@ local function get_body(bufnr, stop_line, query_line, json_body)
 		)
 
 		for _, json_line in ipairs(json_lines) do
-			if json_line:find('^#') == nil then
+			if json_line:find('^%s+#') == nil then
 				json_string = json_string .. utils.replace_env_vars(json_line)
 			end
 		end
@@ -147,7 +147,7 @@ local function get_headers(bufnr, query_line)
 						and header[1]:find('"') == nil
 						-- If header key doesn't contains hashes,
 						-- so we don't get commented headers
-						and header[1]:find('^#') == nil
+						and header[1]:find('^%s+#') == nil
 						-- If header key doesn't contains HTTP methods,
 						-- so we don't get the http method/url
 						and not utils.has_value(http_methods, header[1])
@@ -184,7 +184,7 @@ local function get_accept(bufnr, query_line)
 		)
 
 		for _, accept_data in pairs(accept_line) do
-			if accept_data:find('^#') == nil then
+			if accept_data:find('^%s+#') == nil then
 				accept = utils.split(accept_data, ':')[2]
 			end
 		end
@@ -217,7 +217,7 @@ local function get_auth(bufnr, query_line)
 		)
 
 		for _, auth_data in pairs(auth_line) do
-			if auth_data:find('^#') == nil then
+			if auth_data:find('^%s+#') == nil then
 				-- Split by spaces, e.g. {'Authorization:', 'user:pass'}
 				auth_data = utils.split(auth_data, '%s+')
 				-- {'user', 'pass'}

--- a/plugin/rest-nvim.vim
+++ b/plugin/rest-nvim.vim
@@ -6,6 +6,7 @@ endif
 if exists('g:loaded_rest_nvim') | finish | endif
 
 nnoremap <Plug>RestNvim :lua require('rest-nvim').run()<CR>
+nnoremap <Plug>RestNvimPreview :lua require('rest-nvim').run(true)<CR>
 
 let s:save_cpo = &cpo
 set cpo&vim


### PR DESCRIPTION
This PR aims to fix the comments that should be ignored but they are being parsed actually. They are being ignored in
- headers (including the auth ones)
- JSON body

Known issues:
- JSON syntax highlight doesn't recognize `#` char so it'll not have the proper highlighting in the request body if there are commented fields.