### PR TITLE
feat: be able to use environment variables in headers

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -84,7 +84,7 @@ local function get_body(bufnr, stop_line, query_line, json_body)
 		)
 
 		for _, json_line in ipairs(json_lines) do
-			if json_line:find('^%s+#') == nil then
+			if not json_line:find('^%s+#') then
 				json_string = json_string .. utils.replace_env_vars(json_line)
 			end
 		end
@@ -141,17 +141,19 @@ local function get_headers(bufnr, query_line)
 					header = utils.split(header, ':')
 					if
 						header[1]:lower() ~= 'accept'
-						-- If header key doesn't contains double quotes,
-						-- so we don't get body keys
-						and header[1]:find('"') == nil
+						-- If header key doesn't contains double quotes at the
+						-- start, so we don't get body keys
+						and not header[1]:find('^%s+"')
 						-- If header key doesn't contains hashes,
 						-- so we don't get commented headers
-						and header[1]:find('^%s+#') == nil
+						and not header[1]:find('^%s+#')
 						-- If header key doesn't contains HTTP methods,
 						-- so we don't get the http method/url
 						and not utils.has_value(http_methods, header[1])
 					then
-						headers[header[1]:lower()] = header[2]
+						headers[header[1]:lower()] = utils.replace_env_vars(
+							header[2]
+						)
 					end
 				end
 			end
@@ -183,7 +185,7 @@ local function get_accept(bufnr, query_line)
 		)
 
 		for _, accept_data in pairs(accept_line) do
-			if accept_data:find('^%s+#') == nil then
+			if not accept_data:find('^%s+#') then
 				accept = utils.split(accept_data, ':')[2]
 			end
 		end

--- a/tests/using_env_vars/.env
+++ b/tests/using_env_vars/.env
@@ -1,2 +1,3 @@
 URL=https://reqres.in/api/users
 USERNAME=morpheus
+TOKEN=emacs-is-pinky-stop-using-it

--- a/tests/using_env_vars/post_create_user.http
+++ b/tests/using_env_vars/post_create_user.http
@@ -8,7 +8,7 @@
 # - Body
 POST {{URL}}
 
-# Authorization: {{USER}}:{{PASSWORD}}
+Authorization: Bearer {{TOKEN}}
 
 {
     "name": "{{USERNAME}}",


### PR DESCRIPTION
This PR aims to add the ability to use environment variables for headers values and also cleaned some bad coding styles under the hood. Closes #25 

Test for this feature can be found at [tests/using_env_vars](https://github.com/NTBBloodbath/rest.nvim/tree/feature/header-values-from-env/tests/using_env_vars) directory.