### PR TITLE
allow import files for .http files

### DIFF
--- a/tests/post_create_user_externalfile.http
+++ b/tests/post_create_user_externalfile.http
@@ -1,0 +1,3 @@
+POST https://reqres.in/api/users
+
+< ./user.json

--- a/tests/user.json
+++ b/tests/user.json
@@ -1,0 +1,4 @@
+{
+    "name": "morpheus",
+    "job": "leader"
+}


### PR DESCRIPTION
See #31 

import file directive with `< filename.xyz` will call curl with `-d @filename.xyz`

This works with absolute filenames and for relative filenames (where relative filenames will be interpreted as relative to the .http-file)