### PR TITLE
make plenary.curl handle json parsing

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -97,17 +97,10 @@ local function get_body(bufnr, stop_line, query_line, json_body)
 			end
 		end
 
-		json_string = '{' .. json_string .. '}'
-		json = vim.fn.json_decode(json_string)
+		json =  '{' .. json_string .. '}'
 	end
 
 	go_to_line(bufnr, query_line)
-
-	if json_body and json ~= nil then
-		-- If the body is a JSON request then return it as raw string
-		-- e.g. `-d "{\"foo\":\"bar\"}"`
-		json = utils.tbl_to_str(json)
-	end
 
 	return json
 end
@@ -323,7 +316,7 @@ rest.run = function(verbose)
 		url = parsed_url.url,
 		headers = headers,
 		accept = accept,
-		body = body,
+		raw_body = body,
 		dry_run = verbose and verbose or false,
 	})
 

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -78,7 +78,7 @@ local function get_body(bufnr, stop_line, query_line, json_body)
 	local end_line = 0
 
 	start_line = vim.fn.search('^{', '', stop_line)
-	end_line = vim.fn.search('^}', 'n', stop_line)
+	end_line = vim.fn.searchpair('{', '', '}', 'n', '', stop_line)
 
 	if start_line > 0 then
 		local json_string = ''

--- a/tests/post_create_user.http
+++ b/tests/post_create_user.http
@@ -2,5 +2,9 @@ POST https://reqres.in/api/users
 
 {
     "name": "morpheus",
-    "job": "leader"
+    "job": "leader",
+    "array": ["a", "b", "c"],
+    "object_ugly_closing": {
+      "some_key": "some_value"
+}
 }


### PR DESCRIPTION
Hi @NTBBloodbath I have faced an issue with the rest-nvim handling of json arrays, e.g. ["a", "b"]. Basically, `vim.fn.json_decode()` that is used by `get_body()` decodes arrays as lua tables with curly braces. After passing them to plenary.curl as body, those are not properly encoded back to square brackets - curly braces are passed to curl, and if the API expects an array the request will fail on the server side.

My suggestion is to benefit from recent development in plenary and pass json always as raw string, and let plenary.curl handle it.

As a side thing, after going through the nvim lua api docs, I have found a function that can be used to find the matching curly brace for delineating the body in the http file. This way the parsing method will not be confused by ill-formatted, non-indented json objects for finding the end of the body. 