### PR TITLE
prevent modified flag switch for httpResult

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -21,6 +21,8 @@ local function get_or_create_buf()
 	if existing_bufnr ~= -1 then
 		-- Set modifiable
 		vim.api.nvim_buf_set_option(existing_bufnr, 'modifiable', true)
+                -- Prevent modified flag
+		vim.api.nvim_buf_set_option(existing_bufnr, 'buftype', 'nofile')
 		-- Delete buffer content
 		vim.api.nvim_buf_set_lines(
 			existing_bufnr,
@@ -40,6 +42,7 @@ local function get_or_create_buf()
 	local new_bufnr = vim.api.nvim_create_buf(false, 'nomodeline')
 	vim.api.nvim_buf_set_name(new_bufnr, tmp_name)
 	vim.api.nvim_buf_set_option(new_bufnr, 'ft', 'httpResult')
+        vim.api.nvim_buf_set_option(new_bufnr, 'buftype', 'nofile')
 
 	return new_bufnr
 end


### PR DESCRIPTION
Hi @NTBBloodbath, currently httpResult buffer gets modified flag set to true (there is a plus sign on the statusline) if it is reused for another query. This can lead some users (like me;)) to be asked to save or discard the buffer contents. By changing the buftype option of the httpResult to nofile, makes modified flag to be ignored.

Btw. would you consider changing the stylua indentention to spaces? I think it is more common pattern both across lua neovim plugins, and more professional lua projects,  see [luarocks](https://github.com/luarocks/lua-style-guide) for example.