### PR TITLE
feat: allow skipping SSL verification, closes #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ use {
     'NTBBloodbath/rest.nvim',
     requires = { 'nvim-lua/plenary.nvim' },
     config = function()
-        require('rest-nvim').setup({
-          result_split_horizontal = false,
-        })
+      require("rest-nvim").setup({
+        -- Open request results in a horizontal split
+        result_split_horizontal = false,
+        -- Skip SSL verification, useful for unknown certificates
+        skip_ssl_verification = false,
+      })
     end
 }
 ```
@@ -66,12 +69,17 @@ use {
 By default `rest.nvim` does not have any key mappings so you will not have
 conflicts with any of your existing ones.
 
-To run `rest.nvim` you should map the `<Plug>RestNvim` and `<Plug>RestNvimPreview` commands.
+To run `rest.nvim` you should map the following commands:
+- `<Plug>RestNvim`, run the request under the cursor
+- `<Plug>RestNvimPreview`, preview the request cURL command
+- `<Plug>RestNvimLast`, re-run the last request
 
 ## Settings
 
-* `result_split_horizontal` opens result on a horizontal split (default opens 
-on vertical)
+- `result_split_horizontal` opens result on a horizontal split (default opens 
+    on vertical)
+- `skip_ssl_verification` passes the `-k` flag to cURL in order to skip SSL verification,
+    useful when using unknown certificates
 
 ## Usage
 

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -48,6 +48,16 @@ FEATURES                                                   *rest-nvim-features*
 ===============================================================================
 QUICK START                                             *rest-nvim-quick-start*
 
+After installing `rest.nvim` you will need to configure it using a `setup`
+function, it looks like this by default:
+
+`require("rest-nvim").setup({`
+`  -- Open request results in a horizontal split`
+`  result_split_horizontal = false,`
+`  -- Skip SSL verification, useful for unknown certificates`
+`  skip_ssl_verification = false,`
+`})`
+
 In this section we will be using `https://reqres.in/` for requests.
 
 Let's say we want to create a new user and send our body as a JSON, so we

--- a/lua/rest-nvim/config.lua
+++ b/lua/rest-nvim/config.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local config = {
   result_split_horizontal = false,
+  skip_ssl_verification = false,
 }
 
 --- Get a configuration value

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -319,8 +319,9 @@ rest.run = function(verbose)
     url = parsed_url.url,
     headers = headers,
     -- accept = accept,
+    raw = config.skip_ssl_verification and { "-k" } or nil,
     body = body, -- the request body (string/filepath/table)
-    dry_run = verbose and verbose or false,
+    dry_run = verbose or false,
   })
 
   if not success_req then


### PR DESCRIPTION
This PR aims to allow skipping SSL verification as the title says, this could be useful when dealing with unknown certificates.

To achieve this goal, the changes provides a new `setup()` function option called `skip_ssl_verification` which is `false` by default. If the option `skip_ssl_verification` is `true` then `rest.nvim` will pass the `-k` flag to cURL.

@rafi can you please test it out? :slightly_smiling_face: