### PR TITLE
Highlight request on run() and last()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,14 @@ use {
         result_split_horizontal = false,
         -- Skip SSL verification, useful for unknown certificates
         skip_ssl_verification = false,
-      })
+        -- Highlight request on run
+        highlight = {
+            enabled = true,
+            timeout = 150,
+        },
+        -- Jump to request line on run
+        jump_to_request = false,
+        })
     end
 }
 ```
@@ -100,6 +107,8 @@ To run `rest.nvim` you should map the following commands:
     on vertical)
 - `skip_ssl_verification` passes the `-k` flag to cURL in order to skip SSL verification,
     useful when using unknown certificates
+- `highlight` allows to enable and configure the highlighting of the selected request when send,
+- `jump_to_request` moves the cursor to the selected request line when send,
 
 ## Usage
 

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -56,6 +56,13 @@ function, it looks like this by default:
 `  result_split_horizontal = false,`
 `  -- Skip SSL verification, useful for unknown certificates`
 `  skip_ssl_verification = false,`
+`  -- Highlight request on run`
+`  highlight = {`
+`      enabled = true,`
+`      timeout = 150,`
+`  },`
+`  -- Jump to request line on run`
+`  jump_to_request = false,`
 `})`
 
 In this section we will be using `https://reqres.in/` for requests.

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -4,8 +4,8 @@ local config = {
   result_split_horizontal = false,
   skip_ssl_verification = false,
   highlight = {
-      enabled = true,
-      timeout = 150,
+    enabled = true,
+    timeout = 150,
   },
   jump_to_request = false,
 }

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -3,6 +3,10 @@ local M = {}
 local config = {
   result_split_horizontal = false,
   skip_ssl_verification = false,
+  highlight = {
+      enabled = true,
+      timeout = 150,
+    }
 }
 
 --- Get a configuration value

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -6,7 +6,8 @@ local config = {
   highlight = {
       enabled = true,
       timeout = 150,
-    }
+  },
+  jump_to_request = false,
 }
 
 --- Get a configuration value

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -92,7 +92,7 @@ local function create_callback(method, url)
     -- Only open a new split if the buffer is not loaded into the current window
     if vim.fn.bufwinnr(res_bufnr) == -1 then
       local cmd_split = [[vert sb]]
-      if config.result_split_horizontal == true then
+      if config.result_split_horizontal then
         cmd_split = [[sb]]
       end
       vim.cmd(cmd_split .. res_bufnr)

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -7,7 +7,6 @@ local M = {}
 -- get_or_create_buf checks if there is already a buffer with the rest run results
 -- and if the buffer does not exists, then create a new one
 M.get_or_create_buf = function()
-  log.debug("curl.get_or_create_buf")
   local tmp_name = "rest_nvim_results"
 
   -- Check if the file is already loaded in the buffer
@@ -32,88 +31,94 @@ M.get_or_create_buf = function()
     return existing_bufnr
   end
 
-  log.debug("create new buffer")
   -- Create new buffer
   local new_bufnr = vim.api.nvim_create_buf(false, "nomodeline")
   vim.api.nvim_buf_set_name(new_bufnr, tmp_name)
   vim.api.nvim_buf_set_option(new_bufnr, "ft", "httpResult")
   vim.api.nvim_buf_set_option(new_bufnr, "buftype", "nofile")
 
-  log.debug("exit get_or_create_buf")
   return new_bufnr
+end
+
+local function create_callback(method, url)
+   return function(res)
+      if res.exit ~= 0 then
+        log.error("[rest.nvim] " .. utils.curl_error(res.exit))
+        return
+      end
+      local res_bufnr = M.get_or_create_buf()
+      local json_body = false
+
+      -- Check if the content-type is "application/json" so we can format the JSON
+      -- output later
+      for _, header in ipairs(res.headers) do
+        if string.find(header, "application/json") then
+          json_body = true
+          break
+        end
+      end
+
+    --- Add metadata into the created buffer (status code, date, etc)
+    -- Request statement (METHOD URL)
+     vim.api.nvim_buf_set_lines(res_bufnr, 0, 0, false, { method:upper() .. " " .. url })
+
+      -- HTTP version, status code and its meaning, e.g. HTTP/1.1 200 OK
+      local line_count = vim.api.nvim_buf_line_count(res_bufnr)
+      vim.api.nvim_buf_set_lines(
+        res_bufnr,
+        line_count,
+        line_count,
+        false,
+        { "HTTP/1.1 " .. utils.http_status(res.status) }
+      )
+      -- Headers, e.g. Content-Type: application/json
+      vim.api.nvim_buf_set_lines(
+        res_bufnr,
+        line_count + 1,
+        line_count + 1 + #res.headers,
+        false,
+        res.headers
+      )
+
+      --- Add the curl command results into the created buffer
+      if json_body then
+        -- format JSON body
+        res.body = vim.fn.system("jq", res.body)
+      end
+      local lines = utils.split(res.body, "\n")
+      line_count = vim.api.nvim_buf_line_count(res_bufnr) - 1
+      vim.api.nvim_buf_set_lines(res_bufnr, line_count, line_count + #lines, false, lines)
+
+      -- Only open a new split if the buffer is not loaded into the current window
+      if vim.fn.bufwinnr(res_bufnr) == -1 then
+        local cmd_split = [[vert sb]]
+        if config.result_split_horizontal == true then
+          cmd_split = [[sb]]
+        end
+        vim.cmd(cmd_split .. res_bufnr)
+        -- Set unmodifiable state
+        vim.api.nvim_buf_set_option(res_bufnr, "modifiable", false)
+      end
+
+      -- Send cursor in response buffer to start
+      utils.move_cursor(res_bufnr, 1)
+
+    end
 end
 
 -- curl_cmd runs curl with the passed options, gets or creates a new buffer
 -- and then the results are printed to the recently obtained/created buffer
 -- @param opts curl arguments
 M.curl_cmd = function(opts)
-  local res = curl[opts.method](opts)
   if opts.dry_run then
+    local res = curl[opts.method](opts)
     log.debug("[rest.nvim] Request preview:\n" .. "curl " .. table.concat(res, " "))
     return
+  else
+    opts.callback = vim.schedule_wrap(create_callback(opts.method, opts.url))
+    curl[opts.method](opts)
   end
-
-  if res.exit ~= 0 then
-    error("[rest.nvim] " .. utils.curl_error(res.exit))
-  end
-
-  local res_bufnr = M.get_or_create_buf()
-  local json_body = false
-
-  -- Check if the content-type is "application/json" so we can format the JSON
-  -- output later
-  for _, header in ipairs(res.headers) do
-    if string.find(header, "application/json") then
-      json_body = true
-      break
-    end
-  end
-
-  log.debug("writing to result buffer...")
-  --- Add metadata into the created buffer (status code, date, etc)
-  -- Request statement (METHOD URL)
-  vim.api.nvim_buf_set_lines(res_bufnr, 0, 0, false, { opts.method:upper() .. " " .. opts.url })
-  -- HTTP version, status code and its meaning, e.g. HTTP/1.1 200 OK
-  local line_count = vim.api.nvim_buf_line_count(res_bufnr)
-  vim.api.nvim_buf_set_lines(
-    res_bufnr,
-    line_count,
-    line_count,
-    false,
-    { "HTTP/1.1 " .. utils.http_status(res.status) }
-  )
-  -- Headers, e.g. Content-Type: application/json
-  vim.api.nvim_buf_set_lines(
-    res_bufnr,
-    line_count + 1,
-    line_count + 1 + #res.headers,
-    false,
-    res.headers
-  )
-
-  log.debug("calling jq...")
-  --- Add the curl command results into the created buffer
-  if json_body then
-    -- format JSON body
-    res.body = vim.fn.system("jq", res.body)
-  end
-  local lines = utils.split(res.body, "\n")
-  line_count = vim.api.nvim_buf_line_count(res_bufnr) - 1
-  vim.api.nvim_buf_set_lines(res_bufnr, line_count, line_count + #lines, false, lines)
-
-  -- Only open a new split if the buffer is not loaded into the current window
-  if vim.fn.bufwinnr(res_bufnr) == -1 then
-    local cmd_split = [[vert sb]]
-    if config.result_split_horizontal == true then
-      cmd_split = [[sb]]
-    end
-    vim.cmd(cmd_split .. res_bufnr)
-    -- Set unmodifiable state
-    vim.api.nvim_buf_set_option(res_bufnr, "modifiable", false)
-  end
-
-  -- Send cursor in response buffer to start
-  utils.go_to_line(res_bufnr, 1)
 end
+
 
 return M

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -1,11 +1,13 @@
 local utils = require("rest-nvim.utils")
 local curl = require("plenary.curl")
 local config = require("rest-nvim.config")
+local log = require("plenary.log").new({ plugin = "rest.nvim", level = "debug" })
 
 local M = {}
 -- get_or_create_buf checks if there is already a buffer with the rest run results
 -- and if the buffer does not exists, then create a new one
 M.get_or_create_buf = function()
+  log.debug("curl.get_or_create_buf")
   local tmp_name = "rest_nvim_results"
 
   -- Check if the file is already loaded in the buffer
@@ -30,12 +32,14 @@ M.get_or_create_buf = function()
     return existing_bufnr
   end
 
+  log.debug("create new buffer")
   -- Create new buffer
   local new_bufnr = vim.api.nvim_create_buf(false, "nomodeline")
   vim.api.nvim_buf_set_name(new_bufnr, tmp_name)
   vim.api.nvim_buf_set_option(new_bufnr, "ft", "httpResult")
   vim.api.nvim_buf_set_option(new_bufnr, "buftype", "nofile")
 
+  log.debug("exit get_or_create_buf")
   return new_bufnr
 end
 
@@ -45,7 +49,7 @@ end
 M.curl_cmd = function(opts)
   local res = curl[opts.method](opts)
   if opts.dry_run then
-    print("[rest.nvim] Request preview:\n" .. "curl " .. table.concat(res, " "))
+    log.debug("[rest.nvim] Request preview:\n" .. "curl " .. table.concat(res, " "))
     return
   end
 
@@ -65,6 +69,7 @@ M.curl_cmd = function(opts)
     end
   end
 
+  log.debug("writing to result buffer...")
   --- Add metadata into the created buffer (status code, date, etc)
   -- Request statement (METHOD URL)
   vim.api.nvim_buf_set_lines(res_bufnr, 0, 0, false, { opts.method:upper() .. " " .. opts.url })
@@ -86,6 +91,7 @@ M.curl_cmd = function(opts)
     res.headers
   )
 
+  log.debug("calling jq...")
   --- Add the curl command results into the created buffer
   if json_body then
     -- format JSON body

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -7,7 +7,6 @@ local LastOpts = {}
 
 rest.setup = function(user_configs)
   config.set(user_configs or {})
-  vim.api.nvim_command("hi def link RestNvimSelect Search")
 end
 
 -- run will retrieve the required request information from the current buffer
@@ -52,6 +51,11 @@ rest.last = function()
     vim.api.nvim_err_writeln("[rest.nvim]: Last request not found")
     return
   end
+
+  if config.get("highlight").enabled == true then
+      request.highlight(LastOpts.bufnr, LastOpts.start_line, LastOpts.end_line)
+  end
+
   local success_req, req_err = pcall(curl.curl_cmd, LastOpts)
 
   if not success_req then

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -33,18 +33,17 @@ rest.run = function(verbose)
   }
 
   if config.get("highlight").enabled == true then
-      log.debug("highlighting request")
       request.highlight(result.bufnr, result.start_line, result.end_line)
   end
 
-  -- local success_req, req_err = pcall(curl.curl_cmd, LastOpts)
+  local success_req, req_err = pcall(curl.curl_cmd, LastOpts)
 
-  -- if not success_req then
-  --   vim.api.nvim_err_writeln(
-  --     "[rest.nvim] Failed to perform the request.\nMake sure that you have entered the proper URL and the server is running.\n\nTraceback: "
-  --       .. req_err
-  --   )
-  -- end
+  if not success_req then
+    vim.api.nvim_err_writeln(
+      "[rest.nvim] Failed to perform the request.\nMake sure that you have entered the proper URL and the server is running.\n\nTraceback: "
+        .. req_err
+    )
+  end
 end
 
 -- last will run the last curl request, if available

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -1,5 +1,4 @@
 local rest = {}
-local log = require("plenary.log").new({ plugin = "rest.nvim", level = "debug" })
 local request = require("rest-nvim.request")
 local config = require("rest-nvim.config")
 local curl = require("rest-nvim.curl")

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -6,6 +6,7 @@ local LastOpts = {}
 
 rest.setup = function(user_configs)
   config.set(user_configs or {})
+  vim.api.nvim_command("hi def link RestNvimSelect Search")
 end
 
 -- run will retrieve the required request information from the current buffer
@@ -25,16 +26,24 @@ rest.run = function(verbose)
     raw = config.skip_ssl_verification and { "-k" } or nil,
     body = result.body,
     dry_run = verbose or false,
+    bufnr = result.bufnr,
+    start_line = result.start_line,
+    end_line = result.end_line,
   }
 
-  local success_req, req_err = pcall(curl.curl_cmd, LastOpts)
-
-  if not success_req then
-    vim.api.nvim_err_writeln(
-      "[rest.nvim] Failed to perform the request.\nMake sure that you have entered the proper URL and the server is running.\n\nTraceback: "
-        .. req_err
-    )
+  if config.get("highlight").enabled == true then
+      print("highlighting request")
+      request.highlight(result.bufnr, result.start_line, result.end_line)
   end
+
+  -- local success_req, req_err = pcall(curl.curl_cmd, LastOpts)
+
+  -- if not success_req then
+  --   vim.api.nvim_err_writeln(
+  --     "[rest.nvim] Failed to perform the request.\nMake sure that you have entered the proper URL and the server is running.\n\nTraceback: "
+  --       .. req_err
+  --   )
+  -- end
 end
 
 -- last will run the last curl request, if available

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -1,4 +1,5 @@
 local rest = {}
+local log = require("plenary.log").new({ plugin = "rest.nvim", level = "debug" })
 local request = require("rest-nvim.request")
 local config = require("rest-nvim.config")
 local curl = require("rest-nvim.curl")
@@ -32,7 +33,7 @@ rest.run = function(verbose)
   }
 
   if config.get("highlight").enabled == true then
-      print("highlighting request")
+      log.debug("highlighting request")
       request.highlight(result.bufnr, result.start_line, result.end_line)
   end
 

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -30,7 +30,7 @@ rest.run = function(verbose)
     end_line = result.end_line,
   }
 
-  if config.get("highlight").enabled == true then
+  if config.get("highlight").enabled then
     request.highlight(result.bufnr, result.start_line, result.end_line)
   end
 
@@ -51,7 +51,7 @@ rest.last = function()
     return
   end
 
-  if config.get("highlight").enabled == true then
+  if config.get("highlight").enabled then
     request.highlight(LastOpts.bufnr, LastOpts.start_line, LastOpts.end_line)
   end
 

--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -31,7 +31,7 @@ rest.run = function(verbose)
   }
 
   if config.get("highlight").enabled == true then
-      request.highlight(result.bufnr, result.start_line, result.end_line)
+    request.highlight(result.bufnr, result.start_line, result.end_line)
   end
 
   local success_req, req_err = pcall(curl.curl_cmd, LastOpts)
@@ -52,7 +52,7 @@ rest.last = function()
   end
 
   if config.get("highlight").enabled == true then
-      request.highlight(LastOpts.bufnr, LastOpts.start_line, LastOpts.end_line)
+    request.highlight(LastOpts.bufnr, LastOpts.start_line, LastOpts.end_line)
   end
 
   local success_req, req_err = pcall(curl.curl_cmd, LastOpts)

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -175,7 +175,6 @@ M.get_current_request = function()
     error("No request found")
   end
   local end_line = end_request()
-  -- utils.move_cursor(bufnr, start_line)
 
   local parsed_url = parse_url(vim.fn.getline(start_line))
 
@@ -183,7 +182,11 @@ M.get_current_request = function()
 
   local body = get_body(bufnr, body_start, end_line)
 
-  utils.move_cursor(bufnr,curpos[2], curpos[3])
+  if config.get("jump_to_request") == true then
+    utils.move_cursor(bufnr, start_line)
+  else
+    utils.move_cursor(bufnr,curpos[2], curpos[3])
+  end
 
   return {
     method = parsed_url.method,
@@ -200,7 +203,6 @@ end
 local select_ns = vim.api.nvim_create_namespace('rest-nvim')
 M.highlight = function(bufnr, start_line, end_line)
   local opts = config.get("highlight") or {}
-  -- local higroup = "RestNvimSelect"
   local higroup = "IncSearch"
   local timeout =  opts.timeout or 150
 

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -182,7 +182,7 @@ M.get_current_request = function()
 
   local body = get_body(bufnr, body_start, end_line)
 
-  if config.get("jump_to_request") == true then
+  if config.get("jump_to_request") then
     utils.move_cursor(bufnr, start_line)
   else
     utils.move_cursor(bufnr, curpos[2], curpos[3])

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -216,7 +216,6 @@ M.highlight = function(bufnr, start_line, end_line)
     function()
       if vim.api.nvim_buf_is_valid(bufnr) then
         vim.api.nvim_buf_clear_namespace(bufnr, select_ns, 0, -1)
-      else
       end
     end,
     timeout

--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -148,9 +148,9 @@ local function end_request(bufnr)
   local last_line = vim.fn.line("$")
 
   if next == 0 or (oldlinenumber == last_line) then
-      return last_line
+    return last_line
   else
-      return next - 1
+    return next - 1
   end
 end
 
@@ -185,7 +185,7 @@ M.get_current_request = function()
   if config.get("jump_to_request") == true then
     utils.move_cursor(bufnr, start_line)
   else
-    utils.move_cursor(bufnr,curpos[2], curpos[3])
+    utils.move_cursor(bufnr, curpos[2], curpos[3])
   end
 
   return {
@@ -199,27 +199,31 @@ M.get_current_request = function()
   }
 end
 
-
-local select_ns = vim.api.nvim_create_namespace('rest-nvim')
+local select_ns = vim.api.nvim_create_namespace("rest-nvim")
 M.highlight = function(bufnr, start_line, end_line)
   local opts = config.get("highlight") or {}
   local higroup = "IncSearch"
-  local timeout =  opts.timeout or 150
+  local timeout = opts.timeout or 150
 
   vim.api.nvim_buf_clear_namespace(bufnr, select_ns, 0, -1)
 
   local end_column = string.len(vim.fn.getline(end_line))
 
-  vim.highlight.range(bufnr, select_ns, higroup, {start_line-1,0}, {end_line-1,end_column}, "c", false)
-
-  vim.defer_fn(
-    function()
-      if vim.api.nvim_buf_is_valid(bufnr) then
-        vim.api.nvim_buf_clear_namespace(bufnr, select_ns, 0, -1)
-      end
-    end,
-    timeout
+  vim.highlight.range(
+    bufnr,
+    select_ns,
+    higroup,
+    { start_line - 1, 0 },
+    { end_line - 1, end_column },
+    "c",
+    false
   )
+
+  vim.defer_fn(function()
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_clear_namespace(bufnr, select_ns, 0, -1)
+    end
+  end, timeout)
 end
 
 return M

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -1,14 +1,17 @@
 local random = math.random
+local log = require("plenary.log").new({ plugin = "rest.nvim", level = "debug" })
 math.randomseed(os.time())
 
 local M = {}
 
--- go_to_line moves the cursor to the desired line in the provided buffer
+-- move_cursor moves the cursor to the desired position in the provided buffer
 -- @param bufnr Buffer number, a.k.a id
--- @param line the desired cursor position
-M.go_to_line = function(bufnr, line)
+-- @param line the desired line
+-- @param column the desired column, defaults to 1
+M.move_cursor = function(bufnr, line, column)
+  column = column or 1
   vim.api.nvim_buf_call(bufnr, function()
-    vim.fn.cursor(line, 1)
+    vim.fn.cursor(line, column)
   end)
 end
 

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -1,5 +1,4 @@
 local random = math.random
-local log = require("plenary.log").new({ plugin = "rest.nvim", level = "debug" })
 math.randomseed(os.time())
 
 local M = {}

--- a/tests/external_file/multiple_requests.http
+++ b/tests/external_file/multiple_requests.http
@@ -16,5 +16,5 @@ Content-Type: application/json
 < ./user.json
 
 ####
-
+###
 GET https://reqres.in/api/users?page=5


### PR DESCRIPTION
New feature "highlight request on run() and last()". In order to implement this, we had to switch from synchronous call to plenary-curl to asynchronous with callback. Implementation is similar to the build-in `vim.highlight.on_yank`. This feature is enabled by default.

Additionally, the old feature of moving the cursor to the current request line is disabled by default as the highlighting shows more accurate what is send and in my opinion it is nicer to have the cursor stay in place.

@NTBBloodbath : Any objections?