### PR TITLE
Load .env files in dir of currently opened file

### DIFF
--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -49,12 +49,22 @@ end
 -- returns a table with the variables
 M.read_env_file = function()
   local variables = {}
-  local env_file_path = vim.fn.getcwd() .. "/.env"
-  -- If there's an env file in the current working dir
-  if M.file_exists(env_file_path) then
-    for line in io.lines(env_file_path) do
-      local vars = M.split(line, "=", 1)
-      variables[vars[1]] = vars[2]
+  
+	-- Directories to search for env files
+  local env_file_paths = {
+		-- current working directory 
+		vim.fn.getcwd() .. "/.env", 
+		-- directory of the currently opened file
+		vim.fn.expand("%:p:h") .. "/.env"
+	}
+
+	-- If there's an env file in the current working dir
+  for env_file_path in env_file_paths do
+    if M.file_exists(env_file_path) then
+      for line in io.lines(env_file_path) do
+        local vars = M.split(line, "=", 1)
+        variables[vars[1]] = vars[2]
+      end
     end
   end
 

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -48,18 +48,16 @@ end
 -- read_env_file Reads the environment variables found in the `.env` file and
 -- returns a table with the variables
 M.read_env_file = function()
-  local variables = {}
-  
-	-- Directories to search for env files
+  -- Directories to search for env files
   local env_file_paths = {
-		-- current working directory 
-		vim.fn.getcwd() .. "/.env", 
-		-- directory of the currently opened file
-		vim.fn.expand("%:p:h") .. "/.env"
-	}
+    -- current working directory
+    vim.fn.getcwd() .. "/.env",
+    -- directory of the currently opened file
+    vim.fn.expand("%:p:h") .. "/.env"
+  }
 
-	-- If there's an env file in the current working dir
-  for env_file_path in env_file_paths do
+  -- If there's an env file in the current working dir
+  for k, env_file_path in ipairs(env_file_paths) do
     if M.file_exists(env_file_path) then
       for line in io.lines(env_file_path) do
         local vars = M.split(line, "=", 1)

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -60,7 +60,7 @@ M.read_env_file = function()
   }
 
   -- If there's an env file in the current working dir
-  for k, env_file_path in ipairs(env_file_paths) do
+  for _, env_file_path in ipairs(env_file_paths) do
     if M.file_exists(env_file_path) then
       for line in io.lines(env_file_path) do
         local vars = M.split(line, "=", 1)

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -48,6 +48,9 @@ end
 -- read_env_file Reads the environment variables found in the `.env` file and
 -- returns a table with the variables
 M.read_env_file = function()
+
+  local variables = {}
+
   -- Directories to search for env files
   local env_file_paths = {
     -- current working directory


### PR DESCRIPTION
Hi @NTBBloodbath,

This pr adds the loading of .env files in the directory of the currently opened file.

## Usecase
I have a big monorepo structured like

```
├─ backend
│  └─ requests
│        └─  test.http
└─ frontend
```
 
Currently, I have to place my .env file for common properties in all my .http files in the root folder of my project.
I would like to place them in the same folder where all my requests are.

## Considerations

**Which variables overwrite which?**

Probably .env files in deeper nested directories should overwrite those in upper directories.

**Should .env files in intermediate directories also be loaded?**

Should it also load .env files in `/backend/.env`? Probably it should if that doesn't add a lot of overhead.

Thank you a lot for this awesome plugin @NTBBloodbath,

Cheers, Jim

Edit: 
Sorry for all the fix commits, i don't have a lot of experiences with pr's/lua
