### PR TITLE
feat: add config option for custom dynamic variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ use {
       },
       -- Jump to request line on run
       jump_to_request = false,
-      env_file = '.env'
+      env_file = '.env',
+      custom_dynamic_variables = {},
     })
   end
 }
@@ -113,6 +114,8 @@ To run `rest.nvim` you should map the following commands:
 - `highlight` allows to enable and configure the highlighting of the selected request when send,
 - `jump_to_request` moves the cursor to the selected request line when send,
 - `env_file` specifies file name that consist environment variables (default: .env)
+- `custom_dynamic_variables` allows to extend or overwrite built-in dynamic variable functions
+    (default: {})
 
 ## Usage
 

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -169,7 +169,7 @@ You can extend or overwrite built-in dynamic variables, with the config key
 `  custom_dynamic_variables = {`
 `    -- overwrite built-in`
 `    ['$uuid'] = function()`
-`      return "$uuid"`
+`      return "{{$uuid}}"`
 `    end,`
 `    -- add new dynamic variable function`
 `    ["$date"] = function()`

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -162,6 +162,23 @@ The following dynamic variables are currenty supported:
 To use dynamic variables, the following syntax is used: `{{DYNAMIC_VARIABLE}}`, 
 e.g. `{{$uuid}}`
 
+You can extend or overwrite built-in dynamic variables, with the config key
+`custom_dynamic_variables`:
+
+`require("rest-nvim").setup({`
+`  custom_dynamic_variables = {`
+`    -- overwrite built-in`
+`    ['$uuid'] = function()`
+`      return "$uuid"`
+`    end,`
+`    -- add new dynamic variable function`
+`    ["$date"] = function()`
+`      local os_date = os.date('%Y-%m-%d')`
+`      return os_date`
+`    end,`
+`  },`
+`})`
+
 
 ===============================================================================
 KNOWN ISSUES                                                 *rest-nvim-issues*

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -14,6 +14,7 @@ local config = {
   },
   jump_to_request = false,
   env_file = ".env",
+  custom_dynamic_variables = {},
 }
 
 --- Get a configuration value

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -76,6 +76,7 @@ M.read_env_file = function()
 end
 
 M.read_dynamic_variables = function()
+  local from_config = config.get("custom_dynamic_variables") or {}
   local dynamic_variables = {
     ["$uuid"] = M.uuid,
     ["$timestamp"] = os.time,
@@ -83,6 +84,9 @@ M.read_dynamic_variables = function()
       return math.random(0, 1000)
     end,
   }
+  for k, v in pairs(from_config) do
+    dynamic_variables[k] = v
+  end
   return dynamic_variables
 end
 


### PR DESCRIPTION
Added configuration option to extend or replace built-in dynamic variables.

Example usage:

```lua
require("rest-nvim").setup({
  custom_dynamic_variables = {
    -- overwrite built-in
    ['$uuid'] = function()
      return "{{$uuid}}"
    end,
    -- add new dynamic variable function
    ["$date"] = function()
      local os_date = os.date('%Y-%m-%d')
      return os_date
    end,
  },
})
```