### PR TITLE
Document variables

### DIFF
--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -92,7 +92,7 @@ end
 
 M.get_node_value = function(node, bufnr)
   local start_row, start_col, _, end_col = node:range()
-  local line = api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1]
+  local line = vim.api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1]
   return line and string.sub(line, start_col + 1, end_col):gsub('^["\'](.*)["\']$', '%1') or nil
 end
 

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -90,15 +90,44 @@ M.read_dynamic_variables = function()
   return dynamic_variables
 end
 
+M.get_node_value = function(node, bufnr)
+  local start_row, start_col, _, end_col = node:range()
+  local line = api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1]
+  return line and string.sub(line, start_col + 1, end_col):gsub('"', '') or nil
+end
+
+M.read_document_variables = function()
+  local variables = {}
+  local bufnr = vim.api.nvim_get_current_buf()
+  local parser = vim.treesitter.get_parser(bufnr)
+  if not parser then return variables end
+
+  local first_tree = parser:trees()[1]
+  if not first_tree then return variables end
+
+  local root = first_tree:root()
+  if not root then return variables end
+
+  for node in root:iter_children() do
+    local type = node:type()
+    if type == 'header' then
+      local name = node:named_child(0)
+      local value = node:named_child(1)
+      variables[M.get_node_value(name, bufnr)] = M.get_node_value(value, bufnr)
+    elseif type ~= 'comment' then
+      break
+    end
+  end
+  return variables
+
+end
+
 M.read_variables = function()
   local first = M.read_env_file()
   local second = M.read_dynamic_variables()
+  local third = M.read_document_variables()
 
-  for k, v in pairs(second) do
-    first[k] = v
-  end
-
-  return first
+  return vim.tbl_extend('force', first, second, third)
 end
 
 -- replace_vars replaces the env variables fields in the provided string

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -93,7 +93,7 @@ end
 M.get_node_value = function(node, bufnr)
   local start_row, start_col, _, end_col = node:range()
   local line = api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1]
-  return line and string.sub(line, start_col + 1, end_col):gsub('"', '') or nil
+  return line and string.sub(line, start_col + 1, end_col):gsub('^["\'](.*)["\']$', '%1') or nil
 end
 
 M.read_document_variables = function()


### PR DESCRIPTION
Found this plugin and it's awesome thanks! I was missing fast switching of variables in the document, so I made this feature.
I suppose this will fix #68.

Just an example:
```
# Some API

# Production settings
host: "service.com"
token:  "PRODUCTION_TOKEN"
username: "manager"

# Stage settings
# host: "stage.service.com"
# token:  "STAGE_TOKEN"
# username: "admin"

query: 'where={"query":"test"}'

###

# Get users
GET https://{{host}}/api/users?{{query}}
Authorization: Bearer {{token}}

# Create a user
POST https://{{host}}/api/users
Content-Type: application/json
Authorization: Bearer {{token}}

{
    "name": "{{username}}"
}

```
You may fast change/comment/uncomment the variables you need and keep it with your `http` document.