### PR TITLE
Allow spaces in variable names, and  cross compatibility with $dotenv

### DIFF
--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -161,10 +161,14 @@ end
 -- @param stmt the request statement, e.g., POST http://localhost:3000/foo
 local function parse_url(stmt)
   local parsed = utils.split(stmt, " ")
+  local http_method = parsed[1]
+  table.remove(parsed, 1)
+  local target_url = table.concat(parsed, " ")
+
   return {
-    method = parsed[1],
+    method = http_method,
     -- Encode URL
-    url = utils.encode_url(utils.replace_vars(parsed[2])),
+    url = utils.encode_url(utils.replace_vars(target_url)),
   }
 end
 

--- a/lua/rest-nvim/utils/init.lua
+++ b/lua/rest-nvim/utils/init.lua
@@ -98,6 +98,8 @@ end
 -- @param str Where replace the placers for the env variables
 M.replace_vars = function(str)
   local vars = M.read_variables()
+  -- remove $dotenv tags, which are used by the vscode rest client for cross compatibility
+  str = str:gsub("%$dotenv ", ""):gsub("%$DOTENV ", "")
 
   for var in string.gmatch(str, "{{[^}]+}}") do
     var = var:gsub("{", ""):gsub("}", "")


### PR DESCRIPTION
The VSCode REST client uses a {{$dotenv URL}} pattern to match .env file variables. I work in a team where not everyone uses neovim, so having a cross compatiblity layer for this would be good.

The PR changes how the url is parsed, allowing for spaces in the path and then removing the dotenv references, so that the same markdown works with this client

Example case:

```
GET {{$dotenv URL}}/test/auth
```