### PR TITLE
Config request buffer placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ use {
     require("rest-nvim").setup({
       -- Open request results in a horizontal split
       result_split_horizontal = false,
-      -- Keep the http file buffer below|right when split horizontal|vertical
+      -- Keep the http file buffer above|left when split horizontal|vertical
       result_split_in_place = false,
       -- Skip SSL verification, useful for unknown certificates
       skip_ssl_verification = false,

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ use {
     require("rest-nvim").setup({
       -- Open request results in a horizontal split
       result_split_horizontal = false,
+      -- Keep the http file buffer below|right when split horizontal|vertical
+      result_split_in_place = false,
       -- Skip SSL verification, useful for unknown certificates
       skip_ssl_verification = false,
       -- Highlight request on run
@@ -110,6 +112,8 @@ To run `rest.nvim` you should map the following commands:
 
 - `result_split_horizontal` opens result on a horizontal split (default opens
     on vertical)
+- `result_split_in_place` opens result below|right on horizontal|vertical split
+    (default opens top|left on horizontal|vertical split)
 - `skip_ssl_verification` passes the `-k` flag to cURL in order to skip SSL verification,
     useful when using unknown certificates
 - `highlight` allows to enable and configure the highlighting of the selected request when send,

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -54,7 +54,7 @@ function, it looks like this by default:
 `require("rest-nvim").setup({`
 `  -- Open request results in a horizontal split`
 `  result_split_horizontal = false,`
-` -- Keep the http file buffer below|right when split horizontal|vertical
+` -- Keep the http file buffer above|left when split horizontal|vertical
 ` result_split_in_place = false,
 `  -- Skip SSL verification, useful for unknown certificates`
 `  skip_ssl_verification = false,`

--- a/doc/rest-nvim.txt
+++ b/doc/rest-nvim.txt
@@ -54,6 +54,8 @@ function, it looks like this by default:
 `require("rest-nvim").setup({`
 `  -- Open request results in a horizontal split`
 `  result_split_horizontal = false,`
+` -- Keep the http file buffer below|right when split horizontal|vertical
+` result_split_in_place = false,
 `  -- Skip SSL verification, useful for unknown certificates`
 `  skip_ssl_verification = false,`
 `  -- Highlight request on run`

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -2,10 +2,7 @@ local M = {}
 
 local config = {
   result_split_horizontal = false,
-  result_split = {
-    horizontal = false,
-    in_place = false,
-  },
+  result_split_in_place = false,
   skip_ssl_verification = false,
   highlight = {
     enabled = true,

--- a/lua/rest-nvim/config/init.lua
+++ b/lua/rest-nvim/config/init.lua
@@ -2,6 +2,10 @@ local M = {}
 
 local config = {
   result_split_horizontal = false,
+  result_split = {
+    horizontal = false,
+    in_place = false,
+  },
   skip_ssl_verification = false,
   highlight = {
     enabled = true,

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -101,8 +101,11 @@ local function create_callback(method, url)
     -- Only open a new split if the buffer is not loaded into the current window
     if vim.fn.bufwinnr(res_bufnr) == -1 then
       local cmd_split = [[vert sb]]
-      if config.result_split_horizontal then
+      if config.result_split.horizontal then
         cmd_split = [[sb]]
+      end
+      if config.result_split.in_place then
+        cmd_split = [[bel ]] .. cmd_split
       end
       vim.cmd(cmd_split .. res_bufnr)
       -- Set unmodifiable state

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -101,10 +101,10 @@ local function create_callback(method, url)
     -- Only open a new split if the buffer is not loaded into the current window
     if vim.fn.bufwinnr(res_bufnr) == -1 then
       local cmd_split = [[vert sb]]
-      if config.get('result_split_horizontal') then
+      if config.get("result_split_horizontal") then
         cmd_split = [[sb]]
       end
-      if config.get('result_split_in_place') then
+      if config.get("result_split_in_place") then
         cmd_split = [[bel ]] .. cmd_split
       end
       vim.cmd(cmd_split .. res_bufnr)

--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -101,10 +101,10 @@ local function create_callback(method, url)
     -- Only open a new split if the buffer is not loaded into the current window
     if vim.fn.bufwinnr(res_bufnr) == -1 then
       local cmd_split = [[vert sb]]
-      if config.result_split.horizontal then
+      if config.get('result_split_horizontal') then
         cmd_split = [[sb]]
       end
-      if config.result_split.in_place then
+      if config.get('result_split_in_place') then
         cmd_split = [[bel ]] .. cmd_split
       end
       vim.cmd(cmd_split .. res_bufnr)


### PR DESCRIPTION
Added a new option for the placement of the request buffer:

Current behavior:
```
__________________           _________________________________________________
|GET {{url}}      |         | {{response}}           |  GET {{url}}           |
|                 |   ->    |                        |                        |
|                 |         |                        |                        |
￣￣￣￣￣￣￣￣￣￣￣          ￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣
```
New behavior with 'result_split_in_place = true'
```
__________________           _________________________________________________
|GET {{url}}      |         | GET {{url}}            | {{response}}           |
|                 |   ->    |                        |                        |
|                 |         |                        |                        |
￣￣￣￣￣￣￣￣￣￣￣          ￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣
```