### PR TITLE
fix: result_split_horizontal config getter

### DIFF
--- a/lua/rest-nvim/curl/init.lua
+++ b/lua/rest-nvim/curl/init.lua
@@ -101,7 +101,7 @@ local function create_callback(method, url)
     -- Only open a new split if the buffer is not loaded into the current window
     if vim.fn.bufwinnr(res_bufnr) == -1 then
       local cmd_split = [[vert sb]]
-      if config.result_split_horizontal then
+      if config.get("result_split_horizontal") then
         cmd_split = [[sb]]
       end
       vim.cmd(cmd_split .. res_bufnr)


### PR DESCRIPTION
Currently, the getter for config `result_split_horizontal` is not working because it access the `config` table directly.

I fixed the issue by using `config.get("result_split_horizontal")`.

confirmed working **on my machine** 😃 

### P.S.

I have idea to add config to either show the split in the right (if vertical) or below (if horizontal). should I open issue for that?

the option is to add more config key `reverse_split`, or make a breaking change by deleting existing `result_split_horizontal` then adding:

```lua
  setup {
    -- ....
    split_position = "left", -- possible value: "top" | "right" | "bottom" | "left"
  }
```