### PR TITLE
[FIX] NTBBloodbath/rest.nvim/issues/102: some payloads can confuse rest.nvim

### DIFF
--- a/lua/rest-nvim/request/init.lua
+++ b/lua/rest-nvim/request/init.lua
@@ -36,7 +36,8 @@ local function get_importfile_name(bufnr, start_line, stop_line)
 end
 
 -- get_body retrieves the body lines in the buffer and then returns
--- either a raw string with the body if it is JSON, or a filename. Plenary.curl can distinguish
+-- either a table if the body is a JSON or a raw string if it is a filename
+-- Plenary.curl allows a table or a raw string as body and can distinguish
 -- between strings with filenames and strings with the raw body
 -- @param bufnr Buffer number, a.k.a id
 -- @param start_line Line where body starts
@@ -68,6 +69,11 @@ local function get_body(bufnr, start_line, stop_line)
     if not utils.contains_comments(line) then
       body = body .. utils.replace_vars(line)
     end
+  end
+
+  local is_json, json_body = pcall(vim.fn.json_decode, body)
+  if is_json then
+    return json_body
   end
 
   return body


### PR DESCRIPTION
When plenary.curl is supplied a raw string as body and if this string contains a `$` it checks for a file path and errs. This seems to be a known issue and a [fix](https://github.com/nvim-lua/plenary.nvim/pull/360) is suggested. This seems to be the root cause.


However, I noticed the `plenary.curl` can also take a[ lua table as `body`](https://github.com/nvim-lua/plenary.nvim/blob/9069d14a120cadb4f6825f76821533f2babcab92/lua/plenary/curl.lua#L182-L193). This PR sends a table as the `body` while invoking plenary.curl, whenever possible. This way we can side-step the upstream issue and also exploit the allowed "overloading".