### PR TITLE
Interpret "Authorization: Basic <user>:<pass>" header as basic auth

### DIFF
--- a/lua/rest-nvim/init.lua
+++ b/lua/rest-nvim/init.lua
@@ -25,6 +25,7 @@ rest.run = function(verbose)
     headers = result.headers,
     raw = config.get("skip_ssl_verification") and { "-k" } or nil,
     body = result.body,
+    auth = result.auth,
     dry_run = verbose or false,
     bufnr = result.bufnr,
     start_line = result.start_line,


### PR DESCRIPTION
Trying to add the ability to interpret a special header line `Authorization: Basic <user>:<pass>` as basic authorization. 
This follows the VS code rest plugin's[ style of interpreting basic auth](https://github.com/Huachao/vscode-restclient/blob/master/README.md?plain=1#L307-L309).


---------
```rest
POST https://fake.com/api/some
Authorization: Basic user:password
Content-Type: application/json

{
  "key": "jafa"
}
```
is converted to `curl -sSL --compressed -X 'POST' -H 'Content-Type:  application/json' -d 'key=jafa' -u 'user:password' 'https://fake.com/api/some'`

----------

@NTBBloodbath 
There is an alternative suggestion [here](https://github.com/NTBBloodbath/rest.nvim/issues/89) on how to do the basic auth, both of these styles can live together, IMHO. I went for this style as its compatible with the heavily used VS code. Feel free to reject this if the VS code style is not palatable. Also fine if you have issues with style, let me know I will fix and get back to you.